### PR TITLE
Analyseer platform en onderzoek getDb persistentie

### DIFF
--- a/src/lib/db/repositories/clientCompanyRepository.ts
+++ b/src/lib/db/repositories/clientCompanyRepository.ts
@@ -1,6 +1,6 @@
 import { Collection, Db, ObjectId } from 'mongodb';
 import { ClientCompany, CreateClientCompanyInput } from '../models/ClientCompany';
-import { getDb } from '@/lib/mongodb';
+import { getDatabase } from '@/lib/mongodb';
 
 export class ClientCompanyRepository {
   private collection: Collection<ClientCompany>;
@@ -126,7 +126,7 @@ let repository: ClientCompanyRepository | null = null;
 
 export async function getClientCompanyRepository(): Promise<ClientCompanyRepository> {
   if (!repository) {
-    const db = await getDb();
+    const db = await getDatabase();
     repository = new ClientCompanyRepository(db);
   }
   return repository;


### PR DESCRIPTION
Fixes `getDb` export error by aligning import name with actual function `getDatabase`.

The `clientCompanyRepository.ts` was attempting to import and use a function named `getDb`, but the `mongodb.ts` file actually exports the database connection function as `getDatabase`. This PR corrects the import and usage to `getDatabase` to resolve the runtime error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6773ac0d-0de3-4dd9-85ef-ec51e6daa2e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6773ac0d-0de3-4dd9-85ef-ec51e6daa2e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

